### PR TITLE
docs: refresh secrets, testing, and worker guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,22 +6,36 @@
   - `components/`: Reusable widgets.
   - `screens/`: UI screens (suffix `_screen.dart`).
   - `services/`: Data/Firebase access (suffix `_service.dart`).
-  - `models/`, 
-  - `enums/`, 
-  - `utils/`, 
+  - `models/`,
+  - `enums/`,
+  - `utils/`,
   - `gen/` (generated assets),
   - `firebase_options.dart`.
 - `assets/`: Images and lottie files declared in `pubspec.yaml`.
-- `test/`: Widget/unit tests (`*_test.dart`).
-- Platform folders: `android/`, `ios/`, `web/`.
-- Config: `.env`, `.env.example`, `analysis_options.yaml`, `firebase.json`.
+- `docs/`: Markdown documentation and guides.
+- `cf-workers/`: Cloudflare Workers built with TypeScript and Wrangler.
+- Platform folders: `android/`, `ios/`.
+- Config: `.env`, `.env.example`, `analysis_options.yaml`, `pubspec.yaml`.
 
-## Build, Test, and Dev Commands
-- Install deps: `flutter pub get` — fetches packages.
+## Environment Setup
+### Flutter
+- If `flutter` is not installed, download it for your OS:
+  - [Windows](https://docs.flutter.dev/get-started/install/windows)
+  - [macOS](https://docs.flutter.dev/get-started/install/macos)
+  - [Linux](https://docs.flutter.dev/get-started/install/linux) (or `sudo snap install flutter --classic`)
+- Run `flutter doctor` to ensure all required tooling is configured.
+- Fetch dependencies with `flutter pub get`.
+
+### npm (cf-workers)
+- Workers require Node.js and npm.
+- If missing, install Node.js (e.g., `curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs`).
+- In `cf-workers/`, install dependencies with `npm ci`.
+
+## Build and Dev Commands
 - Generate code: `dart run build_runner build --delete-conflicting-outputs` — builds env/assets helpers.
 - Analyze: `dart analyze` — static checks using `flutter_lints` config.
 - Run app: `flutter run` (e.g., `-d chrome`, `-d ios`, `-d android`).
-- Tests: `flutter test` (optionally `--coverage`).
+- Workers: `npm run dev:<worker>` to run locally, `npm run deploy:<worker>` to deploy.
 - Release builds: `flutter build aab --release`, `flutter build apk --release`, `flutter build ios --release`.
 
 ## Linting
@@ -39,12 +53,13 @@
 - Files: `snake_case.dart` (`file_names` lint). Classes: `PascalCase`. Fields/locals: `camelCase`.
 - Screens end with `...Screen`; services end with `...Service`. Keep widgets small and reusable in `components/`.
 
-## Testing Guidelines
-TBD
+## Pre-commit Checks
+- Before committing, run `dart analyze`.
+- For changes under `cf-workers/`, run `npm test` if defined and verify workers with `npm run dev:<worker>`.
 
 ## Commits & Pull Requests
 - Commits: use imperative, concise subjects; include scope when clear (e.g., `screens: fix crash on movie screen`). Prefer descriptive refactors over generic messages.
-- PRs: include summary, linked issues, screenshots for UI, and test steps. Ensure: app builds, `dart analyze` passes, tests green, and `.env`/secrets are not committed.
+- PRs: include summary, linked issues, screenshots for UI, and verification steps. Ensure: app builds, `dart analyze` passes, and `.env`/secrets are not committed.
 
 ## Security & Configuration
 - Do not commit secrets. Use `.env` + `envied` to generate `lib/utils/env/env.g.dart` via build_runner.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,7 +133,9 @@ Guidelines:
 
 ## Testing
 
-TBD
+- Run static analysis with `dart analyze` to catch issues early.
+- Execute the test suite with `flutter test` before pushing changes.
+- Add widget and unit tests under the `test/` directory to cover new features.
 
 ## Generated Code (Assets & Env)
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,3 +14,4 @@ This document tracks a simple, high-level TODO list for the project. It’s a li
 #### Future improvements
 
 1. Add unit tests
+

--- a/docs/api/APP_PREFERENCES.md
+++ b/docs/api/APP_PREFERENCES.md
@@ -76,4 +76,5 @@ Notes:
 
 **Testing Tips**
 
-TBD
+- Use `SharedPreferences.setMockInitialValues({});` to initialize storage in tests.
+- After setting mock values, run your tests with `flutter test`.

--- a/docs/api/AUTH.md
+++ b/docs/api/AUTH.md
@@ -67,7 +67,9 @@
 
 **Testing**
 
-TBD
+- For unit tests, mock `FirebaseAuth` and `GoogleSignIn` or use the Firebase Auth emulator.
+- Configure the emulator with `FirebaseAuth.instance.useAuthEmulator("localhost", 9099);`.
+- Run the tests with `flutter test`.
 
 **Quick Reference**
 

--- a/docs/api/SECRETS.md
+++ b/docs/api/SECRETS.md
@@ -11,8 +11,9 @@
 - `TMDB_ACCESS_TOKEN` (String): TMDB v4 API Bearer token.
 - `SUBDL_API_KEY` (String): SubDL API key for subtitle downloads.
 - `CF_WORKERS_API_KEY` (String): Cloudflare Workers' API key.
+- `CINEPRO_BASE_URL` (String): Base URL for the CinePro streaming server.
 
-Declare both in `.env` (use `.env.example` as a template) and run the build step to embed/obfuscate values.
+ Declare these in `.env` (use `.env.example` as a template) and run the build step to embed/obfuscate values.
 
 **API**
 
@@ -23,8 +24,10 @@ Declare both in `.env` (use `.env.example` as a template) and run the build step
 - `static String subdlApiKey`
   - API key used for SubDL subtitle queries.
   - Consumed by: `lib/services/subtitle_service.dart` (`api_key` query param).
-- `static String cloudflareProxyUrl`
-  - Cloudflare Worker proxy URL for requests that need proxies.
+- `static String cfWorkersApiKey`
+  - API key injected into Cloudflare Worker requests.
+- `static String cineProBaseUrl`
+  - Base URL used for CinePro streaming server requests.
 **Common Usage**
 
 - TMDB requests auth header:
@@ -39,6 +42,7 @@ Declare both in `.env` (use `.env.example` as a template) and run the build step
   - `TMDB_ACCESS_TOKEN=...`
   - `SUBDL_API_KEY=...`
   - `CF_WORKERS_API_KEY=...`
+  - `CINEPRO_BASE_URL=...`
 - Generate code: `dart run build_runner build --delete-conflicting-outputs`.
 - Verify build: `dart analyze` and run the app.
 
@@ -52,5 +56,5 @@ Declare both in `.env` (use `.env.example` as a template) and run the build step
 
 - File: `lib/services/secrets_service.dart`
 - Generated: `lib/services/secrets_service.g.dart`
-- Env: `.env` with `TMDB_ACCESS_TOKEN`, `SUBDL_API_KEY`, `CF_WORKERS_API_KEY`
+- Env: `.env` with `TMDB_ACCESS_TOKEN`, `SUBDL_API_KEY`, `CF_WORKERS_API_KEY`, `CINEPRO_BASE_URL`
 - Build: `dart run build_runner build --delete-conflicting-outputs`

--- a/docs/cf-workers/ANDROID_CLIENT.md
+++ b/docs/cf-workers/ANDROID_CLIENT.md
@@ -106,7 +106,7 @@ GitHub Actions: see `.github/workflows/deploy-cf-workers.yml`. It installs deps 
 
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
-- `FIREBASE_SERVICE_ACCOUNT_JSON` (service account JSON value)
+- `CF_WORKERS_API_KEY`
 
 ## Routes and domains
 

--- a/docs/cf-workers/ZIP_TO_VTT.md
+++ b/docs/cf-workers/ZIP_TO_VTT.md
@@ -41,14 +41,12 @@ curl "http://127.0.0.1:8787/?url=https%3A%2F%2Fexample.com%2Fsubs.zip" -i
 
 ### Authentication
 
-- Requires an `Authorization: Bearer <Firebase ID token>` header on non-`OPTIONS` requests.
-- ID tokens are verified using the Firebase Admin SDK only.
-- The Firebase project is read from `FIREBASE_PROJECT_ID` (set in each worker’s `wrangler.toml`).
+- Requires `Authorization: Bearer <CF_WORKERS_API_KEY>` on non-`OPTIONS` requests.
 
 ### Secrets
 
-- Provide the Firebase service account JSON to the worker as a secret named `FIREBASE_SERVICE_ACCOUNT_JSON`.
-- In CI, set a repository secret `FIREBASE_SERVICE_ACCOUNT_JSON` with the entire JSON content.
+- Provide a repository secret `CF_WORKERS_API_KEY` containing your API key.
+- The GitHub Actions workflow uploads it to the worker via `wrangler secret put` before deploy.
 
 ### Behavior
 
@@ -75,6 +73,7 @@ GitHub Actions: see `.github/workflows/deploy-cf-workers.yml`. It installs deps 
 
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
+- `CF_WORKERS_API_KEY`
 
 ## Routes and domains
 


### PR DESCRIPTION
## Summary
- document CinePro base URL and Cloudflare Worker API key in secrets doc
- add testing guidance for auth, preferences, and architecture docs
- clarify Cloudflare worker guides to use CF_WORKERS_API_KEY for auth and deployment
- expand AGENTS with project structure and environment setup, removing Flutter test instructions
- specify OS-specific Flutter install links

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a75bae7483209dd4c7ccd8d64cee