### PR TITLE
Inline double tap indicator builder

### DIFF
--- a/lib/components/semo_player.dart
+++ b/lib/components/semo_player.dart
@@ -834,16 +834,6 @@ class _SemoPlayerState extends State<SemoPlayer> with TickerProviderStateMixin {
   }
 
   Widget _buildDoubleTapIndicator({required bool isLeft}) {
-    final TextStyle textStyle = Theme.of(context).textTheme.titleSmall?.copyWith(
-              color: Colors.white,
-              fontWeight: FontWeight.bold,
-            ) ??
-        const TextStyle(
-          color: Colors.white,
-          fontWeight: FontWeight.bold,
-          fontSize: 18,
-        );
-
     final String label = "${isLeft ? "-" : "+"}${_seekDuration.abs()} s";
 
     return Container(
@@ -862,7 +852,13 @@ class _SemoPlayerState extends State<SemoPlayer> with TickerProviderStateMixin {
             size: 32,
           ),
           const SizedBox(height: 6),
-          Text(label, style: textStyle),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- replace the standalone double-tap indicator widget with an inline builder inside `SemoPlayer`

## Testing
- dart analyze *(fails: `dart` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c94bf269b48320b17885d0eadd1460