### PR TITLE
Adjust theme font sizes responsively

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -178,16 +178,53 @@ class Semo extends StatelessWidget {
         ),
       );
 
+  ThemeData _applyFontScale(ThemeData baseTheme, double scale) {
+    TextTheme scaledTextTheme = baseTheme.textTheme.apply(fontSizeFactor: scale);
+    AppBarTheme appBarTheme = baseTheme.appBarTheme;
+    TextStyle? titleStyle = appBarTheme.titleTextStyle;
+
+    return baseTheme.copyWith(
+      textTheme: scaledTextTheme,
+      appBarTheme: appBarTheme.copyWith(
+        titleTextStyle: titleStyle?.copyWith(
+          fontSize: (titleStyle.fontSize ?? 24) * scale,
+        ),
+      ),
+    );
+  }
+
+  double _resolveFontScale(double width) {
+    double scale = width / 375;
+    if (scale < 0.85) {
+      scale = 0.85;
+    } else if (scale > 1.25) {
+      scale = 1.25;
+    }
+    return scale;
+  }
+
   @override
   Widget build(BuildContext context) => BlocProvider<AppBloc>(
         create: (BuildContext context) => AppBloc()..init(),
         child: BlocBuilder<AppBloc, AppState>(
-          builder: (BuildContext context, AppState state) => MaterialApp(
-            title: "Semo",
-            debugShowCheckedModeBanner: false,
-            theme: _buildTheme(),
-            home: const SplashScreen(),
-          ),
+          builder: (BuildContext context, AppState state) {
+            ThemeData baseTheme = _buildTheme();
+            return MaterialApp(
+              title: "Semo",
+              debugShowCheckedModeBanner: false,
+              theme: baseTheme,
+              builder: (BuildContext context, Widget? child) {
+                MediaQueryData mediaQuery = MediaQuery.of(context);
+                double scale = _resolveFontScale(mediaQuery.size.width);
+                ThemeData scaledTheme = _applyFontScale(baseTheme, scale);
+                return Theme(
+                  data: scaledTheme,
+                  child: child ?? const SizedBox.shrink(),
+                );
+              },
+              home: const SplashScreen(),
+            );
+          },
         ),
       );
 }


### PR DESCRIPTION
## Summary
- add helpers to compute responsive font scaling from screen width
- wrap MaterialApp with a themed builder so typography adjusts to the scale

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db7e55d6b4832087bd6cd9c99cd150