### PR TITLE
Update Semo player zoom scaling

### DIFF
--- a/lib/components/semo_player.dart
+++ b/lib/components/semo_player.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:math";
 
 import "package:audio_video_progress_bar/audio_video_progress_bar.dart";
 import "package:dio/dio.dart";
@@ -666,7 +667,14 @@ class _SemoPlayerState extends State<SemoPlayer> with TickerProviderStateMixin {
     }
 
     final double screenAR = screenSize.width / screenSize.height;
-    return screenAR / videoAR;
+    final double widthScale = screenAR / videoAR;
+    final double heightScale = videoAR / screenAR;
+
+    if (!widthScale.isFinite || !heightScale.isFinite) {
+      return 1.0;
+    }
+
+    return max(1.0, max(widthScale, heightScale));
   }
 
   Future<void> _handleStreamFailure(Object? error) async {


### PR DESCRIPTION
## Summary
- update the zoom scale computation to always provide a fill-screen zoom option
- import dart:math to leverage max while keeping invalid scale safeguards

## Testing
- `dart analyze` *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddaec611508320b75d82c00c580db0