### PR TITLE
Fix buffering indicator after seek

### DIFF
--- a/lib/components/semo_player.dart
+++ b/lib/components/semo_player.dart
@@ -498,6 +498,16 @@ class _SemoPlayerState extends State<SemoPlayer> with TickerProviderStateMixin {
     final bool shouldResume = _shouldResumeAfterSeek;
     _shouldResumeAfterSeek = false;
 
+    if (_isBuffering) {
+      if (mounted) {
+        setState(() {
+          _isBuffering = false;
+        });
+      } else {
+        _isBuffering = false;
+      }
+    }
+
     if (shouldResume) {
       unawaited(
         _player.play().catchError((Object error, StackTrace stackTrace) {


### PR DESCRIPTION
## Summary
- reset the buffering flag when a pending seek completes so the loading indicator is cleared

## Testing
- Not run (dart command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de2094c7c88320bedf8161547c915f