### PR TITLE
feat: add responsive navigation to fragments screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -115,13 +115,16 @@ class Semo extends StatelessWidget {
           iconTheme: IconThemeData(color: _onPrimary),
           centerTitle: false,
         ),
-        navigationBarTheme: NavigationBarThemeData(
-          backgroundColor: _background,
-          indicatorColor: _primary.withValues(alpha: 0.3),
-          labelBehavior: NavigationDestinationLabelBehavior.onlyShowSelected,
-          labelTextStyle: WidgetStatePropertyAll<TextStyle>(
-            TextStyle(color: _primary),
-          ),
+        bottomAppBarTheme: BottomAppBarThemeData(
+          color: _surface,
+          elevation: 0,
+          height: 72,
+        ),
+        floatingActionButtonTheme: FloatingActionButtonThemeData(
+          backgroundColor: _primary,
+          foregroundColor: _onPrimary,
+          elevation: 0,
+          shape: const CircleBorder(),
         ),
         textTheme: TextTheme(
           titleLarge: GoogleFonts.freckleFace(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,11 +79,11 @@ Future<void> _initializeRemoteConfig() async {
 class Semo extends StatelessWidget {
   const Semo({super.key});
 
-  static const Color _primary = Color(0xFFAB261D);
-  static const Color _background = Color(0xFF120201);
-  static const Color _surface = Color(0xFF250604);
-  static const Color _onPrimary = Colors.white;
-  static const Color _onSurface = Colors.white54;
+  final Color _primary = const Color(0xFFAB261D);
+  final Color _background = const Color(0xFF120201);
+  final Color _surface = const Color(0xFF250604);
+  final Color _onPrimary = Colors.white;
+  final Color _onSurface = Colors.white54;
 
   ThemeData _buildTheme() => ThemeData(
         useMaterial3: true,
@@ -106,83 +106,91 @@ class Semo extends StatelessWidget {
           scrolledUnderElevation: 0,
           backgroundColor: _background,
           titleTextStyle: GoogleFonts.freckleFace(
-            textStyle: const TextStyle(
+            textStyle: TextStyle(
               fontSize: 24,
               fontWeight: FontWeight.w900,
               color: _onPrimary,
             ),
           ),
-          iconTheme: const IconThemeData(color: _onPrimary),
+          iconTheme: IconThemeData(color: _onPrimary),
           centerTitle: false,
+        ),
+        navigationBarTheme: NavigationBarThemeData(
+          backgroundColor: _background,
+          indicatorColor: _primary.withValues(alpha: 0.3),
+          labelBehavior: NavigationDestinationLabelBehavior.onlyShowSelected,
+          labelTextStyle: WidgetStatePropertyAll<TextStyle>(
+            TextStyle(color: _primary),
+          ),
         ),
         textTheme: TextTheme(
           titleLarge: GoogleFonts.freckleFace(
-            textStyle: const TextStyle(
+            textStyle: TextStyle(
               fontSize: 38,
               fontWeight: FontWeight.w900,
               color: _onPrimary,
             ),
           ),
           titleMedium: GoogleFonts.freckleFace(
-            textStyle: const TextStyle(
+            textStyle: TextStyle(
               fontSize: 32,
               fontWeight: FontWeight.w900,
               color: _onPrimary,
             ),
           ),
           titleSmall: GoogleFonts.freckleFace(
-            textStyle: const TextStyle(
+            textStyle: TextStyle(
               fontSize: 24,
               fontWeight: FontWeight.w900,
               color: _onPrimary,
             ),
           ),
           displayLarge: GoogleFonts.lexend(
-            textStyle: const TextStyle(
+            textStyle: TextStyle(
               fontSize: 18,
               color: _onPrimary,
             ),
           ),
           displayMedium: GoogleFonts.lexend(
-            textStyle: const TextStyle(
+            textStyle: TextStyle(
               fontSize: 15,
               color: _onPrimary,
             ),
           ),
           displaySmall: GoogleFonts.lexend(
-            textStyle: const TextStyle(
+            textStyle: TextStyle(
               fontSize: 14,
               color: _onPrimary,
             ),
           ),
         ),
-        progressIndicatorTheme: const ProgressIndicatorThemeData(
+        progressIndicatorTheme: ProgressIndicatorThemeData(
           color: _primary,
         ),
-        dialogTheme: const DialogThemeData(
+        dialogTheme: DialogThemeData(
           backgroundColor: _surface,
         ),
-        tabBarTheme: const TabBarThemeData(
+        tabBarTheme: TabBarThemeData(
           indicatorColor: _primary,
           labelColor: _primary,
           dividerColor: _surface,
           unselectedLabelColor: _onSurface,
         ),
-        menuTheme: const MenuThemeData(
+        menuTheme: MenuThemeData(
           style: MenuStyle(
             backgroundColor: WidgetStatePropertyAll<Color>(_surface),
           ),
         ),
-        bottomSheetTheme: const BottomSheetThemeData(
+        bottomSheetTheme: BottomSheetThemeData(
           showDragHandle: true,
           backgroundColor: _surface,
-          shape: RoundedRectangleBorder(
+          shape: const RoundedRectangleBorder(
             borderRadius: BorderRadius.vertical(
               top: Radius.circular(25),
             ),
           ),
         ),
-        snackBarTheme: const SnackBarThemeData(
+        snackBarTheme: SnackBarThemeData(
           behavior: SnackBarBehavior.floating,
           backgroundColor: _surface,
         ),

--- a/lib/screens/fragments_screen.dart
+++ b/lib/screens/fragments_screen.dart
@@ -27,6 +27,7 @@ class FragmentsScreen extends BaseScreen {
 }
 
 class _FragmentsScreenState extends BaseScreenState<FragmentsScreen> with TickerProviderStateMixin {
+  static const double _drawerBreakpoint = 900;
   int _selectedPageIndex = 0;
   List<FragmentScreen> _fragmentScreens = <FragmentScreen>[];
   late TabController _tabController;
@@ -86,70 +87,23 @@ class _FragmentsScreenState extends BaseScreenState<FragmentsScreen> with Ticker
         ),
       );
 
-  @override
-  String get screenName => "Fragments";
-
-  @override
-  Future<void> initializeScreen() async {
-    _selectedPageIndex = widget.initialPageIndex;
-    _tabController = TabController(
-      length: 2,
-      initialIndex: widget.initialFavoritesTabIndex,
-      vsync: this,
-    );
-    _initFragments();
-  }
-
-  @override
-  Widget buildContent(BuildContext context) {
-    if (_fragmentScreens.isEmpty) {
-      return const Scaffold();
-    }
-
-    return Scaffold(
-      appBar: AppBar(
+  Widget _buildBottomNavigationBar() => NavigationBar(
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        title: Text(_fragmentScreens[_selectedPageIndex].title),
-        leading: Builder(
-          builder: (BuildContext context) => IconButton(
-            icon: const Icon(Icons.menu),
-            onPressed: () => Scaffold.of(context).openDrawer(),
-          ),
-        ),
-        bottom: _selectedPageIndex == 2
-            ? TabBar(
-                controller: _tabController,
-                tabs: const <Tab>[
-                  Tab(
-                    icon: Icon(Icons.movie),
-                    text: "Movies",
-                  ),
-                  Tab(
-                    icon: Icon(Icons.video_library),
-                    text: "TV Shows",
-                  ),
-                ],
-              )
-            : null,
-        actions: <Widget>[
-          (isConnectedToInternet && _selectedPageIndex <= 1)
-              ? IconButton(
-                  icon: const Icon(
-                    Icons.search,
-                    color: Colors.white,
-                  ),
-                  onPressed: () {
-                    NavigationHelper.navigate(
-                      context,
-                      SearchScreen(mediaType: _fragmentScreens[_selectedPageIndex].mediaType),
-                    );
-                  },
-                )
-              : Container(),
+        indicatorColor: Theme.of(context).primaryColor.withValues(alpha: 0.3),
+        selectedIndex: _selectedPageIndex,
+        onDestinationSelected: (int index) {
+          setState(() => _selectedPageIndex = index);
+        },
+        destinations: <NavigationDestination>[
+          for (final FragmentScreen fragment in _fragmentScreens)
+            NavigationDestination(
+              icon: Icon(fragment.icon),
+              label: fragment.title,
+            ),
         ],
-      ),
-      body: _fragmentScreens[_selectedPageIndex].widget,
-      drawer: SafeArea(
+      );
+
+  Widget _buildDrawer() => SafeArea(
         top: true,
         left: true,
         right: true,
@@ -159,7 +113,7 @@ class _FragmentsScreenState extends BaseScreenState<FragmentsScreen> with Ticker
           child: ListView(
             padding: EdgeInsets.zero,
             children: <Widget>[
-              Container(
+              SizedBox(
                 height: 200,
                 child: Center(
                   child: Assets.images.appIcon.image(
@@ -182,7 +136,82 @@ class _FragmentsScreenState extends BaseScreenState<FragmentsScreen> with Ticker
             ],
           ),
         ),
-      ),
+      );
+
+  @override
+  String get screenName => "Fragments";
+
+  @override
+  Future<void> initializeScreen() async {
+    _selectedPageIndex = widget.initialPageIndex;
+    _tabController = TabController(
+      length: 2,
+      initialIndex: widget.initialFavoritesTabIndex,
+      vsync: this,
+    );
+    _initFragments();
+  }
+
+  @override
+  Widget buildContent(BuildContext context) {
+    if (_fragmentScreens.isEmpty) {
+      return const Scaffold();
+    }
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final bool useDrawer = constraints.maxWidth >= _drawerBreakpoint;
+
+        return Scaffold(
+          appBar: AppBar(
+            automaticallyImplyLeading: useDrawer,
+            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+            title: Text(_fragmentScreens[_selectedPageIndex].title),
+            leading: useDrawer
+                ? Builder(
+                    builder: (BuildContext context) => IconButton(
+                      icon: const Icon(Icons.menu),
+                      onPressed: () => Scaffold.of(context).openDrawer(),
+                    ),
+                  )
+                : null,
+            bottom: _selectedPageIndex == 2
+                ? TabBar(
+                    controller: _tabController,
+                    tabs: const <Tab>[
+                      Tab(
+                        icon: Icon(Icons.movie),
+                        text: "Movies",
+                      ),
+                      Tab(
+                        icon: Icon(Icons.video_library),
+                        text: "TV Shows",
+                      ),
+                    ],
+                  )
+                : null,
+            actions: <Widget>[
+              (isConnectedToInternet && _selectedPageIndex <= 1)
+                  ? IconButton(
+                      icon: const Icon(
+                        Icons.search,
+                        color: Colors.white,
+                      ),
+                      onPressed: () {
+                        NavigationHelper.navigate(
+                          context,
+                          SearchScreen(mediaType: _fragmentScreens[_selectedPageIndex].mediaType),
+                        );
+                      },
+                    )
+                  : Container(),
+            ],
+          ),
+          body: _fragmentScreens[_selectedPageIndex].widget,
+          drawer: useDrawer ? _buildDrawer() : null,
+          bottomNavigationBar: useDrawer ? null : _buildBottomNavigationBar(),
+        );
+      },
     );
   }
 }

--- a/lib/screens/fragments_screen.dart
+++ b/lib/screens/fragments_screen.dart
@@ -92,21 +92,50 @@ class _FragmentsScreenState extends BaseScreenState<FragmentsScreen> with Ticker
         ),
       );
 
-  Widget _buildBottomNavigationBar() => NavigationBar(
-        selectedIndex: _selectedPageIndex,
-        onDestinationSelected: (int index) {
+  Widget _buildBottomAppBarItem(int index) {
+    final FragmentScreen fragment = _fragmentScreens[index];
+    final bool isSelected = _selectedPageIndex == index;
+    final Color activeColor = Theme.of(context).primaryColor;
+    final Color inactiveColor = Colors.white54.withValues(alpha: 0.5);
+
+    return Material(
+      color: Colors.transparent,
+      child: IconButton(
+        icon: AnimatedContainer(
+          duration: const Duration(milliseconds: 250),
+          child: Icon(
+            fragment.icon,
+            size: isSelected ? 30 : 24,
+            color: isSelected ? activeColor : inactiveColor,
+          ),
+        ),
+        onPressed: () {
           setState(() => _selectedPageIndex = index);
         },
-        destinations: <NavigationDestination>[
-          for (int i = 0; i < _fragmentScreens.length; i++)
-            NavigationDestination(
-              icon: Icon(
-                _fragmentScreens[i].icon,
-                color: i == _selectedPageIndex ? Theme.of(context).primaryColor : Colors.white54.withValues(alpha: 0.5),
+      ),
+    );
+  }
+
+  Widget _buildBottomAppBar() => BottomAppBar(
+        shape: const CircularNotchedRectangle(),
+        notchMargin: 8,
+        clipBehavior: Clip.antiAlias,
+        child: SizedBox(
+          height: kBottomNavigationBarHeight,
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: Row(
+                  mainAxisSize: MainAxisSize.max,
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: <Widget>[
+                    for (int i = 0; i < _fragmentScreens.length; i++) _buildBottomAppBarItem(i),
+                  ],
+                ),
               ),
-              label: _fragmentScreens[i].title,
-            ),
-        ],
+            ],
+          ),
+        ),
       );
 
   Widget _buildDrawer() => SafeArea(
@@ -197,25 +226,37 @@ class _FragmentsScreenState extends BaseScreenState<FragmentsScreen> with Ticker
                   )
                 : null,
             actions: <Widget>[
-              (isConnectedToInternet && _selectedPageIndex <= 1)
-                  ? IconButton(
-                      icon: const Icon(
-                        Icons.search,
-                        color: Colors.white,
-                      ),
-                      onPressed: () {
-                        NavigationHelper.navigate(
-                          context,
-                          SearchScreen(mediaType: _fragmentScreens[_selectedPageIndex].mediaType),
-                        );
-                      },
-                    )
-                  : Container(),
+              if (useDrawer && isConnectedToInternet && _selectedPageIndex <= 1)
+                IconButton(
+                  icon: const Icon(
+                    Icons.search,
+                    color: Colors.white,
+                  ),
+                  onPressed: () {
+                    NavigationHelper.navigate(
+                      context,
+                      SearchScreen(mediaType: _fragmentScreens[_selectedPageIndex].mediaType),
+                    );
+                  },
+                ),
             ],
           ),
           body: _fragmentScreens[_selectedPageIndex].widget,
           drawer: useDrawer ? _buildDrawer() : null,
-          bottomNavigationBar: useDrawer ? null : _buildBottomNavigationBar(),
+          bottomNavigationBar: useDrawer ? null : _buildBottomAppBar(),
+          floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+          floatingActionButton: (!useDrawer && isConnectedToInternet && _selectedPageIndex <= 1)
+              ? FloatingActionButton(
+                  onPressed: () {
+                    NavigationHelper.navigate(
+                      context,
+                      SearchScreen(mediaType: _fragmentScreens[_selectedPageIndex].mediaType),
+                    );
+                  },
+                  shape: const CircleBorder(),
+                  child: const Icon(Icons.search),
+                )
+              : null,
         );
       },
     );

--- a/lib/screens/fragments_screen.dart
+++ b/lib/screens/fragments_screen.dart
@@ -93,17 +93,18 @@ class _FragmentsScreenState extends BaseScreenState<FragmentsScreen> with Ticker
       );
 
   Widget _buildBottomNavigationBar() => NavigationBar(
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        indicatorColor: Theme.of(context).primaryColor.withValues(alpha: 0.3),
         selectedIndex: _selectedPageIndex,
         onDestinationSelected: (int index) {
           setState(() => _selectedPageIndex = index);
         },
         destinations: <NavigationDestination>[
-          for (final FragmentScreen fragment in _fragmentScreens)
+          for (int i = 0; i < _fragmentScreens.length; i++)
             NavigationDestination(
-              icon: Icon(fragment.icon),
-              label: fragment.title,
+              icon: Icon(
+                _fragmentScreens[i].icon,
+                color: i == _selectedPageIndex ? Theme.of(context).primaryColor : Colors.white54.withValues(alpha: 0.5),
+              ),
+              label: _fragmentScreens[i].title,
             ),
         ],
       );

--- a/lib/screens/fragments_screen.dart
+++ b/lib/screens/fragments_screen.dart
@@ -48,16 +48,21 @@ class _FragmentsScreenState extends BaseScreenState<FragmentsScreen> with Ticker
           mediaType: MediaType.tvShows,
         ),
         FragmentScreen(
-            icon: Icons.favorite,
-            title: "Favorites",
-            widget: TabBarView(
-              controller: _tabController,
-              children: const <Widget>[
-                FavoritesScreen(mediaType: MediaType.movies),
-                FavoritesScreen(mediaType: MediaType.tvShows),
-              ],
-            )),
-        const FragmentScreen(icon: Icons.settings, title: "Settings", widget: SettingsScreen()),
+          icon: Icons.favorite,
+          title: "Favorites",
+          widget: TabBarView(
+            controller: _tabController,
+            children: const <Widget>[
+              FavoritesScreen(mediaType: MediaType.movies),
+              FavoritesScreen(mediaType: MediaType.tvShows),
+            ],
+          ),
+        ),
+        const FragmentScreen(
+          icon: Icons.settings,
+          title: "Settings",
+          widget: SettingsScreen(),
+        ),
       ];
     });
   }


### PR DESCRIPTION
## Summary
- add a responsive breakpoint to switch between drawer and bottom navigation in the fragments screen
- reuse the existing drawer layout for wide layouts and introduce a bottom navigation bar for compact screens

## Testing
- Not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de23300c4483208e59a2d822728c90